### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-github-action
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-github-action
 
 jobs:
   deploy:
@@ -15,7 +16,7 @@ jobs:
 
       - name: Setup variables and Generate deployment package
         run: |
-          VERSION_LABEL="${{ github.sha }}-$(date +%s)"
+          echo "VERSION_LABEL=${{ github.sha }}-$(date +%s)" >> $GITHUB_ENV
 
           cd api
           zip -r ../deploy.zip . -x '*.git*'
@@ -28,6 +29,6 @@ jobs:
             aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             application_name: golang
             environment_name: main
-            version_label: $VERSION_LABEL
+            version_label: ${{ env.VERSION_LABEL }}
             region: ap-southeast-1
             deployment_package: deploy.zip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Setup variables and Generate deployment package
         run: |
-          echo "VERSION_LABEL=${{ github.sha }}-$(date +%s)" >> $GITHUB_ENV
+          echo "VERSION_LABEL=${{ github.sha }}-$(date +\%s)" >> $GITHUB_ENV
 
           cd api
           zip -r ../deploy.zip . -x '*.git*'


### PR DESCRIPTION
- update version label
- fix deployment error: unable to get secrets
- in github settings: store the secrets in `Repository secrets` instead of `Environment secrets`
![image](https://github.com/user-attachments/assets/b160bc33-c1fa-493f-95af-1f133150cbff)
